### PR TITLE
`ActivityApi` fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ddc-primitives"
 version = "7.3.2"
-source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=dev#dde443c9d86e23a8d4c662b2426db85de448efe6"
+source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=002-activity-api-fixes#1f2bead6ec15d3e675b3dc22928e621e14e7873a"
 dependencies = [
  "blake2",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ddc-primitives"
 version = "7.3.2"
-source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=002-activity-api-fixes#1f2bead6ec15d3e675b3dc22928e621e14e7873a"
+source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=002-activity-api-fixes#1beb89f18c2f9b15a46c36fb34234d3804b71eae"
 dependencies = [
  "blake2",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ddc-primitives"
 version = "7.3.2"
-source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=002-activity-api-fixes#1beb89f18c2f9b15a46c36fb34234d3804b71eae"
+source = "git+https://github.com/Cerebellum-Network/ddc-primitives.git?branch=dev#3aba0e702e8d39a98fc0b38ea5e3e1e315371e35"
 dependencies = [
  "blake2",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { version = "14.0.0", default-features = false }
 
 
 # Cere dependencies
-ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
+ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "002-activity-api-fixes", default-features = false }
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { version = "14.0.0", default-features = false }
 
 
 # Cere dependencies
-ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "002-activity-api-fixes", default-features = false }
+ddc-primitives = { git = "https://github.com/Cerebellum-Network/ddc-primitives.git", branch = "dev", default-features = false }
 
 
 

--- a/build.rs
+++ b/build.rs
@@ -97,6 +97,7 @@ fn main() -> Result<()> {
     );
     prost_build.type_attribute("activity_tree.PhdPayload", "#[derive(Eq, PartialOrd)]");
     prost_build.type_attribute("activity_tree.EhdPayload", "#[derive(Eq, PartialOrd)]");
+    prost_build.type_attribute("inspection.PathValue", "#[derive(Eq, PartialOrd, Ord)]");
     prost_build.type_attribute("inspection.VerifiedUsage", "#[derive(Eq, PartialOrd, Ord)]");
     prost_build.type_attribute(
         "inspection.EraVerifiedUsage",

--- a/src/client.rs
+++ b/src/client.rs
@@ -308,14 +308,14 @@ impl<'a> DdcClient<'a> {
         indexes: Option<&[u64]>,
     ) -> Result<ApiResponse<proto::activity::GetRecordsResponse>, http::Error> {
         let mut url = format!(
-            "{}/activity/v1/records?tcaId={}&record_id_gte={}&record_id_lte={}",
+            "{}/activity/v1/records?tcaId={}&recordIdGte={}&recordIdLte={}",
             self.base_url,
             tca_id,
             hex::encode(record_id_gte),
             hex::encode(record_id_lte),
         );
         if let Some(b) = bucket_id {
-            url = format!("{}&bucket_id={}", url, b);
+            url = format!("{}&bucketId={}", url, b);
         }
         if let Some(idx) = indexes {
             let joined = idx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,22 +590,6 @@ pub mod proto {
         }
     }
 
-    impl From<&inspection::PathValue> for activity_tree::ActivityNode {
-        fn from(v: &inspection::PathValue) -> Self {
-            activity_tree::ActivityNode {
-                put_count: v.put_count,
-                get_count: v.get_count,
-                stored: v.stored,
-                transferred: v.transferred,
-                cpu_units: v.cpu_units,
-                gpu_units: v.gpu_units,
-                ram_units: v.ram_units,
-                compute_count: v.compute_count,
-                record_id_range_start: Default::default(),
-                record_id_range_end: Default::default(),
-            }
-        }
-    }
 
     impl inspection::InspectionPath {
         /// Blake2b-256 hash of protobuf-serialized bytes, returned as raw 32-byte array.


### PR DESCRIPTION
## Summary

\`UnverifiedUsage.usage\` and \`VerifiedUsage.usage\` are now \`PathValue\` directly (see ddc-proto#3). The old \`From<&PathValue> for ActivityNode\` impl that produced empty-range ActivityNodes for the legacy shape is unreachable — drop it.

Adds \`#[derive(Eq, PartialOrd, Ord)]\` on \`inspection.PathValue\` so the existing Ord-derived containers (\`VerifiedUsage\`, \`EraVerifiedUsage\`) typecheck with \`Option<PathValue>\` inside.

Bumps the \`ddc-proto\` submodule pointer to the feature branch tip.
